### PR TITLE
Add force to rm

### DIFF
--- a/solr_optimizer.sh
+++ b/solr_optimizer.sh
@@ -62,7 +62,7 @@ sanityCheck()
 writeClearPid()
 {
   if [ "$1" -eq "0" ]; then
-    rm $pidFile
+    rm -f $pidFile
   else
   # This will overwrite an old file if present. That's ok though.
     echo $myPid > $pidFile


### PR DESCRIPTION
Without the `-f` we may have the script fail because some servers default to interactive for `rm` command...

It will be prompting like:
```
rm: remove regular file /var/run/solr_optimizer.pid
```