### PR TITLE
Add checks for missing environment variable

### DIFF
--- a/solr_optimizer.sh
+++ b/solr_optimizer.sh
@@ -57,6 +57,8 @@ sanityCheck()
       solrManifest=$CATALINA_HOME/webapps/solr/META-INF/MANIFEST.MF
       ls $solrManifest > /dev/null 2>&1
       checkSafe $? "can not find solr"
+    else
+      checkSafe 1 "can not find solr"
     fi
   fi
 }

--- a/solr_optimizer.sh
+++ b/solr_optimizer.sh
@@ -50,9 +50,14 @@ sanityCheck()
   which curl > /dev/null
   checkSafe $? "can't find curl"
 
-  # Check for solr where we think it is normallu installed
+  # Check for solr where we think it is normally installed
   if [ ! -f $solrManifest ]; then
-    checkSafe 1 "can not find solr"
+    if [ -f /etc/profile.d/fedora.sh ]; then
+      source /etc/profile.d/fedora.sh
+      solrManifest=$CATALINA_HOME/webapps/solr/META-INF/MANIFEST.MF
+      ls $solrManifest > /dev/null 2>&1
+      checkSafe $? "can not find solr"
+    fi
   fi
 }
 

--- a/solr_optimizer.sh
+++ b/solr_optimizer.sh
@@ -55,12 +55,10 @@ sanityCheck()
     if [ -f /etc/profile.d/fedora.sh ]; then
       source /etc/profile.d/fedora.sh
       solrManifest=$CATALINA_HOME/webapps/solr/META-INF/MANIFEST.MF
-      ls $solrManifest > /dev/null 2>&1
-      checkSafe $? "can not find solr"
-    else
-      checkSafe 1 "can not find solr"
     fi
   fi
+  ls $solrManifest > /dev/null 2>&1
+  checkSafe $? "can not find solr"
 }
 
 # }}}


### PR DESCRIPTION
When run as root, root's environment does not have $CATALINA_HOME set
when running without a tty (ie. when cron calls the script)